### PR TITLE
♻️ Reopen: Issue/chen

### DIFF
--- a/src/genpp/configs/data/dataloader/debug.yaml
+++ b/src/genpp/configs/data/dataloader/debug.yaml
@@ -1,8 +1,8 @@
 # Standard DataLoader configuration
 # batch_size: null  # Determined by the batch size of the generators found in data.batch size
 # which is in the weatherbench2_full.yaml config
-prefetch_factor: 3
-num_workers: 4
-multiprocessing_context: "forkserver"
-pin_memory: true
-persistent_workers: true # Keep workers alive between epochs
+num_workers: 0
+prefetch_factor: !!null
+multiprocessing_context: !!null
+pin_memory: !!null
+persistent_workers: !!null

--- a/src/genpp/configs/data/weatherbench2_full_fast.yaml
+++ b/src/genpp/configs/data/weatherbench2_full_fast.yaml
@@ -67,9 +67,9 @@ _dataloader_template: &dataloader_template
   batch_size: ${data.batch_size} # Use the actual batch size here
   prefetch_factor: ${data.dataloader.prefetch_factor}
   num_workers: ${data.dataloader.num_workers}
-  multiprocessing_context: "forkserver"
+  multiprocessing_context: ${data.dataloader.multiprocessing_context}
   pin_memory: ${data.dataloader.pin_memory}
-  persistent_workers: true # Keep workers alive between epochs
+  persistent_workers: ${data.dataloader.persistent_workers}
 
 module:
   _target_: genpp.data.fast_dataset_simple.FastWeatherBench2DataModule

--- a/src/genpp/models/cgm/chen.py
+++ b/src/genpp/models/cgm/chen.py
@@ -13,7 +13,7 @@ from genpp.models.layers import CropND, LocallyConnected2D, UNet, _get_scale_td
 from genpp.models.utils import BaseModule, FitScaleVarianceTDMixin
 
 
-class BaseChenModel(BaseModule, ABC):
+class BaseChenModel(BaseModule, ABC, FitScaleVarianceTDMixin):
     """Base class for generative models with mean, std, and noise decoder components.
 
     Args:
@@ -72,7 +72,13 @@ class BaseChenModel(BaseModule, ABC):
             self.embedding = nn.Embedding(
                 num_embeddings=self.gridpoints, embedding_dim=embedding_dim
             )
-        self.register_buffer("scale_variance_td", None)  # To be fitted via callback
+        self.register_buffer(
+            "scale_variance_td", None
+        )  # To be fitted via callback (see setup method)
+
+    def setup(self, stage) -> None:
+        if stage == "fit":
+            self._fit_scale_variance_td()
 
     # Abstract components - to be implemented by subclasses
     @property
@@ -367,7 +373,7 @@ class FcChenModel(BaseChenModel):
         return full_input_repeated_noise
 
 
-class CNNChenModel(BaseChenModel, FitScaleVarianceTDMixin):
+class CNNChenModel(BaseChenModel):
     """CNN-based Chen model.
     In this model, both the std_model and the noise_decoder are separate UNets.
     Args:
@@ -419,10 +425,6 @@ class CNNChenModel(BaseChenModel, FitScaleVarianceTDMixin):
 
         if self.use_embedding:
             self.embedding = nn.Embedding(self.height * self.width, self.embedding_dim)
-
-    def setup(self, stage):
-        if stage == "fit":
-            self._fit_scale_variance_td()
 
     @property
     def mean_model(self) -> nn.Module:

--- a/src/genpp/models/test.ipynb
+++ b/src/genpp/models/test.ipynb
@@ -13,12 +13,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "96171f93",
+   "execution_count": 2,
+   "id": "40fd05f0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch"
+    "import hydra\n",
+    "\n",
+    "from genpp import BASE_DIR\n",
+    "from genpp.configs import register_resolvers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b6393997",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "register_resolvers()"
    ]
   },
   {
@@ -31,236 +44,142 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "4d58ab4c",
+   "execution_count": 4,
+   "id": "e13a7e36",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from genpp.models.chen import FcChenModel"
+    "with hydra.initialize_config_dir(version_base=None, config_dir=str(BASE_DIR / \"configs\")):\n",
+    "    cfg = hydra.compose(config_name=\"base_chen\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "36d62afd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = FcChenModel(\n",
-    "    in_features=29,\n",
-    "    out_features=2,\n",
-    "    meta_features=5,\n",
-    "    height=5,\n",
-    "    width=5,\n",
-    "    noise_dim=5,\n",
-    "    hidden_dim_std=50,\n",
-    "    hidden_dim_decoder=100,\n",
-    "    embedding_dim=5,\n",
-    "    n_samples_train=50,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "516dbf3d",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "torch.Size([8, 50, 5, 5, 2])"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test_input = torch.cat(\n",
-    "    (torch.randn(8, 5, 5, 2 * 29 + 5), torch.randint(0, 5, (8, 5, 5, 1))), dim=-1\n",
-    ")\n",
-    "test_out = model.forward(test_input)\n",
-    "test_out.shape  # Shape is good 🥳"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "cdcb4809",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "FcChenModel(\n",
-       "  (final_activation): Identity()\n",
-       "  (embedding): Embedding(25, 5)\n",
-       "  (_mean_model): Sequential(\n",
-       "    (0): LocallyConnected2D()\n",
-       "    (1): Rearrange('b h w o -> b 1 h w o')\n",
-       "  )\n",
-       "  (_std_model): Sequential(\n",
-       "    (0): Flatten(start_dim=1, end_dim=-1)\n",
-       "    (1): Linear(in_features=725, out_features=50, bias=True)\n",
-       "    (2): ELU(alpha=1.0)\n",
-       "    (3): Linear(in_features=50, out_features=5, bias=True)\n",
-       "    (4): Softplus(beta=1.0, threshold=20.0)\n",
-       "    (5): Rearrange('b noise_dim -> b 1 noise_dim')\n",
-       "  )\n",
-       "  (_noise_decoder): Sequential(\n",
-       "    (0): Flatten(start_dim=1, end_dim=-1)\n",
-       "    (1): Linear(in_features=1705, out_features=100, bias=True)\n",
-       "    (2): ELU(alpha=1.0)\n",
-       "    (3): Linear(in_features=100, out_features=50, bias=True)\n",
-       "    (4): Rearrange('(b n) (h w o) -> b n h w o', n=50, h=5, w=5, o=2)\n",
-       "  )\n",
-       ")"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "0006e490",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def count_parameters(model):\n",
-    "    return sum(p.numel() for p in model.parameters() if p.requires_grad)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "c40e9997",
+   "id": "557ba043",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of trainable parameters: 213,830\n"
+      "Configuration hash: 05a2d862df574c3ec09a73a2516597b76945436332ad35785c3a5fe80dbc1c8c\n",
+      "Cached tensor data found. Verifying configuration...\n",
+      "Using cached tensor data from /Users/moritzfeik/Developer/GENPP/src/genpp/data/weatherbench2/cache/tensor_05a2d862df574c3ec09a73a2516597b76945436332ad35785c3a5fe80dbc1c8c.pt.\n"
      ]
     }
    ],
    "source": [
-    "num_params = count_parameters(model)\n",
-    "print(f\"Number of trainable parameters: {num_params:,}\")"
+    "datamodule = hydra.utils.instantiate(cfg.data.module)\n",
+    "datamodule.prepare_data()\n",
+    "datamodule.setup(\"fit\")\n",
+    "dataloader = datamodule.train_dataloader()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "34e4cbdc",
+   "execution_count": 6,
+   "id": "d127715f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from genpp.models.loss import EnergyScore"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "2f76fce2",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([[28.2654, 20.9128],\n",
-       "        [30.2670, 23.2879],\n",
-       "        [29.1640, 31.2433],\n",
-       "        [21.2035, 20.4556],\n",
-       "        [22.5275, 30.4445],\n",
-       "        [29.7365, 26.4877],\n",
-       "        [26.1146, 28.5335],\n",
-       "        [27.8131, 26.1854]], grad_fn=<SubBackward0>)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "es = EnergyScore()\n",
-    "test_y = torch.randn(8, 5, 5, 2)  # Example target tensor\n",
-    "es(test_out, test_y)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "55be8a65",
-   "metadata": {},
-   "source": [
-    "## Test CNNChen"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "df781588",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torch\n",
+    "cfg.model.n_samples_train = 16  # for testing purposes only\n",
     "\n",
-    "from genpp.models.chen import CNNChenModel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "38056eff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test_data = torch.cat(\n",
-    "    (torch.randn(8, 32, 48, 2 * 29 + 5), torch.randint(0, 32 * 48, (8, 32, 48, 1))), dim=-1\n",
-    ")  # Example input tensor\n",
-    "model = CNNChenModel(\n",
-    "    in_features=29,\n",
-    "    out_features=2,\n",
-    "    meta_features=5,\n",
-    "    noise_dim=1,\n",
-    "    embedding_dim=5,\n",
-    "    n_samples_train=50,\n",
-    "    width=48,\n",
-    "    height=32,\n",
-    "    padding=(2, 2, 3, 3),\n",
+    "model = hydra.utils.instantiate(\n",
+    "    cfg.model, rescaler=datamodule.y_reverseModules if cfg.model.use_rescaler else None\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4e107de9",
+   "execution_count": 8,
+   "id": "20166c67",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "torch.Size([8, 50, 28, 42, 2])"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "You have turned on `Trainer(detect_anomaly=True)`. This will significantly slow down compute speed and is recommended only for model debugging.\n",
+      "GPU available: True (mps), used: False\n",
+      "TPU available: False, using: 0 TPU cores\n",
+      "HPU available: False, using: 0 HPUs\n",
+      "/Users/moritzfeik/Developer/GENPP/.pixi/envs/dev/lib/python3.13/site-packages/lightning/pytorch/trainer/setup.py:177: GPU available but not used. You can set it by doing `Trainer(accelerator='gpu')`.\n",
+      "/Users/moritzfeik/Developer/GENPP/.pixi/envs/dev/lib/python3.13/site-packages/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py:76: Starting from v1.9.0, `tensorboardX` has been removed as a dependency of the `lightning.pytorch` package, due to potential conflicts with other packages in the ML ecosystem. For this reason, `logger=True` will use `CSVLogger` as the default logger, unless the `tensorboard` or `tensorboardX` packages are found. Please `pip install lightning[extra]` or one of them to enable TensorBoard support by default\n",
+      "Fitting scale_variance~TD:   0%|          | 0/171 [00:00<?, ?it/s]/Users/moritzfeik/Developer/GENPP/.pixi/envs/dev/lib/python3.13/site-packages/torch/utils/data/dataloader.py:684: UserWarning: 'pin_memory' argument is set as true but not supported on MPS now, then device pinned memory won't be used.\n",
+      "  warnings.warn(warn_msg)\n",
+      "Fitting scale_variance~TD: 100%|██████████| 171/171 [00:06<00:00, 27.78it/s]\n",
+      "\n",
+      "  | Name             | Type            | Params | Mode \n",
+      "-------------------------------------------------------------\n",
+      "0 | final_activation | FinalActivation | 0      | train\n",
+      "1 | loss_fn          | EnergyScore     | 0      | train\n",
+      "2 | embedding        | Embedding       | 6.4 K  | train\n",
+      "3 | crop             | CropND          | 0      | train\n",
+      "4 | _mean_model      | Sequential      | 68.8 K | train\n",
+      "5 | _std_model       | Sequential      | 157 K  | train\n",
+      "6 | _noise_decoder   | Sequential      | 169 K  | train\n",
+      "-------------------------------------------------------------\n",
+      "401 K     Trainable params\n",
+      "0         Non-trainable params\n",
+      "401 K     Total params\n",
+      "1.607     Total estimated model params size (MB)\n",
+      "29        Modules in train mode\n",
+      "0         Modules in eval mode\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                                                           \r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/moritzfeik/Developer/GENPP/.pixi/envs/dev/lib/python3.13/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:252: You requested to overfit but enabled train dataloader shuffling. We are turning off the train dataloader shuffling for you.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 43:  80%|████████  | 8/10 [01:14<00:18,  0.11it/s, v_num=3, train_loss=110.0, val_loss_var_0=100.0, val_loss_var_1=88.00, val_loss=123.0] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Detected KeyboardInterrupt, attempting graceful shutdown ...\n"
+     ]
+    },
+    {
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
+      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
+      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
+      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+     ]
     }
    ],
    "source": [
-    "res = model(test_data)\n",
-    "res.shape  # Should be [8, 5, 28, 42, 2], due to the padding being removed in the output"
+    "trainer = hydra.utils.instantiate(\n",
+    "    cfg.trainer,\n",
+    "    logger=None,\n",
+    "    detect_anomaly=True,\n",
+    "    accelerator=\"cpu\",\n",
+    "    max_epochs=50,\n",
+    "    overfit_batches=10,\n",
+    "    check_val_every_n_epoch=5,\n",
+    ")\n",
+    "trainer.fit(model, datamodule=datamodule)"
    ]
   }
  ],

--- a/src/genpp/models/utils.py
+++ b/src/genpp/models/utils.py
@@ -54,7 +54,8 @@ class BaseModule(L.LightningModule, ABC):
 
 
 class FitScaleVarianceTDMixin:
-    """Mixin class to add scale_variance_td fitting functionality to LightningModules."""
+    """Mixin class to add scale_variance_td fitting functionality to LightningModules.
+    Note: it is essential that the preds and obs are scaled the same way"""
 
     def _fit_scale_variance_td(self) -> None:
         """Fit a regression of the form absolute_prediction_error ~ LeadTime for each variable.
@@ -105,7 +106,7 @@ class FitScaleVarianceTDMixin:
                 obs = rearrange(obs, "b c h w -> c (b h w)")
                 diff = (obs - nwp).abs()
                 ones = torch.ones_like(diff)
-                X = torch.stack([ones, td], dim=1)
+                X = torch.stack([ones, td], dim=1)  # [n_vars, 2, n_samples]
                 y = diff
 
                 # The rearrange is the same as calling the transpose on the last two dims if X

--- a/src/genpp/test.ipynb
+++ b/src/genpp/test.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "id": "29466139",
    "metadata": {},
    "outputs": [],
@@ -33,7 +33,7 @@
     "from genpp import BASE_DIR\n",
     "from genpp.configs import register_resolvers\n",
     "\n",
-    "from genpp.models.callbacks import FitScaleVarianceTDCallback"
+    "from genpp.models.layers import CropND"
    ]
   },
   {
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "15344a22",
    "metadata": {},
    "outputs": [],
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "id": "c7f0958d",
    "metadata": {},
    "outputs": [
@@ -69,7 +69,7 @@
      "text": [
       "Configuration hash: 05a2d862df574c3ec09a73a2516597b76945436332ad35785c3a5fe80dbc1c8c\n",
       "Cached tensor data found. Verifying configuration...\n",
-      "Using cached tensor data.\n"
+      "Using cached tensor data from /home/feik/GenPP/src/genpp/data/weatherbench2/cache/tensor_05a2d862df574c3ec09a73a2516597b76945436332ad35785c3a5fe80dbc1c8c.pt.\n"
      ]
     }
    ],
@@ -83,81 +83,110 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "44f2da73",
+   "execution_count": null,
+   "id": "0a893085",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from tqdm import tqdm\n",
+    "from einops import rearrange\n",
+    "\n",
+    "\n",
+    "def _fit_scale_variance_td(dl, crop) -> None:\n",
+    "    # Access the training dataloader\n",
+    "    train_loader = dl\n",
+    "    if train_loader is None:\n",
+    "        raise ValueError(\"Training dataloader is not available.\")\n",
+    "\n",
+    "    crop_layer = crop\n",
+    "    A = None\n",
+    "    b = None\n",
+    "\n",
+    "    with torch.no_grad():\n",
+    "        pbar = tqdm(train_loader, desc=\"Fitting scale_variance~TD\")\n",
+    "        for batch in pbar:\n",
+    "            nwp, obs, td = batch[\"x\"], batch[\"y\"], batch[\"timedelta\"]\n",
+    "            # The NWP vars we need are the first n_vars\n",
+    "            nwp = nwp[\"predicted_vars\"]\n",
+    "\n",
+    "            # Initialize A and b\n",
+    "            if A is None:\n",
+    "                A = torch.zeros((nwp.shape[1], 2, 2)).to(nwp)\n",
+    "            if b is None:\n",
+    "                b = torch.zeros((nwp.shape[1], 2)).to(nwp)\n",
+    "\n",
+    "            if crop_layer is not None:\n",
+    "                nwp = crop_layer(nwp)\n",
+    "\n",
+    "            # If shapes don't match, crop obs as well\n",
+    "            if nwp.shape != obs.shape:\n",
+    "                obs = crop_layer(obs)  # type: ignore\n",
+    "\n",
+    "            # Now nwp and obs should have the same shape and no padding\n",
+    "            # We can run the regression now\n",
+    "            td = rearrange(td, \"b -> b 1 1 1\")\n",
+    "            td = td.expand_as(obs)\n",
+    "            td = rearrange(td, \"b c h w -> c (b h w)\")\n",
+    "            nwp = rearrange(nwp, \"b c h w -> c (b h w)\")\n",
+    "            obs = rearrange(obs, \"b c h w -> c (b h w)\")\n",
+    "            diff = (obs - nwp).abs()\n",
+    "            ones = torch.ones_like(diff)\n",
+    "            X = torch.stack([ones, td], dim=1)\n",
+    "            y = diff\n",
+    "\n",
+    "            # The rearrange is the same as calling the transpose on the last two dims if X\n",
+    "            A += torch.bmm(X, rearrange(X, \"c a b -> c b a\"))\n",
+    "            b += torch.bmm(X, y.unsqueeze(-1)).squeeze(-1)\n",
+    "\n",
+    "    betas = torch.linalg.solve(A, b)\n",
+    "    # The first dimension is the variable dimension\n",
+    "    # The second dimension is the intercept and slope\n",
+    "    print(f\"Registered buffer with {betas}\")\n",
+    "    return betas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "474b739a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crop = CropND(padding=(0, 1, 1, 2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3d2ef9cf",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-      "GPU available: True (mps), used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "HPU available: False, using: 0 HPUs\n",
-      "`Trainer(overfit_batches=1)` was configured so 1 batch will be used.\n",
-      "/Users/moritzfeik/Developer/GENPP/.pixi/envs/dev/lib/python3.13/site-packages/lightning/pytorch/callbacks/model_checkpoint.py:658: Checkpoint directory /Users/moritzfeik/Developer/GENPP/src/genpp/checkpoints exists and is not empty.\n",
-      "\n",
-      "  | Name             | Type            | Params | Mode \n",
-      "-------------------------------------------------------------\n",
-      "0 | final_activation | FinalActivation | 0      | train\n",
-      "1 | loss_fn          | EnergyScore     | 0      | train\n",
-      "2 | embedding        | Embedding       | 6.4 K  | train\n",
-      "3 | crop             | CropND          | 0      | train\n",
-      "4 | _mean_model      | Sequential      | 68.8 K | train\n",
-      "5 | _std_model       | Sequential      | 157 K  | train\n",
-      "6 | _noise_decoder   | Sequential      | 169 K  | train\n",
-      "-------------------------------------------------------------\n",
-      "401 K     Trainable params\n",
-      "0         Non-trainable params\n",
-      "401 K     Total params\n",
-      "1.607     Total estimated model params size (MB)\n",
-      "29        Modules in train mode\n",
-      "0         Modules in eval mode\n",
-      "/Users/moritzfeik/Developer/GENPP/.pixi/envs/dev/lib/python3.13/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:252: You requested to overfit but enabled train dataloader shuffling. We are turning off the train dataloader shuffling for you.\n",
-      "/Users/moritzfeik/Developer/GENPP/.pixi/envs/dev/lib/python3.13/site-packages/torch/utils/data/dataloader.py:684: UserWarning: 'pin_memory' argument is set as true but not supported on MPS now, then device pinned memory won't be used.\n",
-      "  warnings.warn(warn_msg)\n",
-      "Fitting scale_variance~TD: 100%|██████████| 171/171 [00:04<00:00, 35.41it/s]\n"
+      "Fitting scale_variance~TD: 100%|██████████| 171/171 [00:05<00:00, 29.60it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 4: 100%|██████████| 1/1 [00:02<00:00,  0.36it/s, val_loss_var_0=193.0, val_loss_var_1=180.0, val_loss=264.0, train_loss=244.0]"
+      "Registered buffer with tensor([[0.0849, 0.0996],\n",
+      "        [0.1960, 0.2183]])\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Detected KeyboardInterrupt, attempting graceful shutdown ...\n"
-     ]
-    },
-    {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
-      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
-      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
-      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+      "\n"
      ]
     }
    ],
    "source": [
-    "model = hydra.utils.instantiate(cfg.model)\n",
-    "trainer = hydra.utils.instantiate(\n",
-    "    cfg.trainer,\n",
-    "    logger=False,\n",
-    "    overfit_batches=1,\n",
-    "    num_sanity_val_steps=0,\n",
-    "    callbacks=[FitScaleVarianceTDCallback()],\n",
-    ")\n",
-    "\n",
-    "trainer.fit(model, datamodule)"
+    "betas = _fit_scale_variance_td(train_dataloader, crop)"
    ]
   }
  ],

--- a/src/genpp/train.py
+++ b/src/genpp/train.py
@@ -2,7 +2,6 @@ import warnings
 
 import hydra
 import lightning as L
-import torch
 from omegaconf import DictConfig, OmegaConf
 
 from genpp.configs import register_resolvers
@@ -12,7 +11,6 @@ from genpp.configs import register_resolvers
 def train(cfg: DictConfig) -> None:
     warnings.filterwarnings("ignore", category=SyntaxWarning)
     register_resolvers()
-    torch.set_float32_matmul_precision("medium")
 
     # Set seed for reproducibility
     if hasattr(cfg, "seed"):


### PR DESCRIPTION
This tries to fix #8 again and reopens #9

This pull request introduces several improvements and refactorings to the data loading configuration, model utility mixins, and testing infrastructure for the project. The main changes include making the data loader configuration more flexible and explicit, improving the fitting of scale-variance time dependency in models, and updating the test notebooks for better reproducibility and clarity.

**Data Loading Configuration Improvements:**

* Added a standard DataLoader configuration (`debug.yaml`) with explicit defaults for `num_workers`, `prefetch_factor`, `multiprocessing_context`, `pin_memory`, and `persistent_workers` to improve clarity and debugging.
* Updated `weatherbench2_full_fast.yaml` to reference all DataLoader parameters from the central config, allowing more flexible overrides and reducing hardcoding.
* Added clarifying comments to `standard.yaml` and improved documentation for `persistent_workers`.

**Model Utilities and Fitting Enhancements:**

* Refactored `BaseChenModel` to inherit from `FitScaleVarianceTDMixin`, and added a `setup` method to fit `scale_variance_td` during the "fit" stage, improving modularity and ensuring correct initialization. [[1]](diffhunk://#diff-d983e3e4a85ca6c13d32892228910c1eaf946f564275559aa40e9e20ada8bf91L16-R16) [[2]](diffhunk://#diff-d983e3e4a85ca6c13d32892228910c1eaf946f564275559aa40e9e20ada8bf91L75-R81)
* Removed redundant mixin inheritance from `CNNChenModel` and clarified where `scale_variance_td` fitting occurs. [[1]](diffhunk://#diff-d983e3e4a85ca6c13d32892228910c1eaf946f564275559aa40e9e20ada8bf91L370-R376) [[2]](diffhunk://#diff-d983e3e4a85ca6c13d32892228910c1eaf946f564275559aa40e9e20ada8bf91L423-L426)
* Improved the docstring and internal documentation of `FitScaleVarianceTDMixin` for clarity and maintainability. [[1]](diffhunk://#diff-97cb2120cb81132b41743b3b1a38f1fe33dccd5b99a912ff93491251f66e4a65L57-R58) [[2]](diffhunk://#diff-97cb2120cb81132b41743b3b1a38f1fe33dccd5b99a912ff93491251f66e4a65L108-R109)